### PR TITLE
Allow 0 rating and still display stars

### DIFF
--- a/directives/rating/rating.js
+++ b/directives/rating/rating.js
@@ -37,7 +37,7 @@ angular.module('FundooDirectiveTutorial', [])
         };
 
         scope.$watch('ratingValue', function(oldVal, newVal) {
-          if (newVal) {
+          if (newVal || newVal == 0) {
             updateStars();
           }
         });


### PR DESCRIPTION
Having a 0 rating would not display any stars as "if(newVal)" would evaluate as false and the "updateStars" would not run.
